### PR TITLE
Allow takeWhileInclusive to receive an amount

### DIFF
--- a/extensions/take-while-inclusive.js
+++ b/extensions/take-while-inclusive.js
@@ -2,8 +2,8 @@
 
 const libExt = require('library-extensions');
 
-module.exports = libExt.create('takeWhileInclusive', (obs, condition) =>
+module.exports = libExt.create('takeWhileInclusive', (obs, condition, amount) =>
   obs.publish(
     result => result.takeWhile(condition)
-      .merge(result.skipWhile(condition).take(1))
+      .merge(result.skipWhile(condition).take(amount || 1))
   ));

--- a/test/extensions/take-while-inclusive-test.js
+++ b/test/extensions/take-while-inclusive-test.js
@@ -20,4 +20,23 @@ describe('takeWhileInclusive', () => {
       }
     );
   });
+
+  it('should take elements until the specified amount after the condition is true', done => {
+    const obs = Rx.Observable.range(0, 5);
+    takeWhileInclusive.extend(obs);
+    const tester = sinon.spy();
+    obs.takeWhileInclusive(v => v < 2, 3).forEach(
+      tester,
+      e => expect.fail(null, null, e.message),
+      () => {
+        expect(tester).to.have.callCount(5);
+        expect(tester).to.have.been.calledWith(0);
+        expect(tester).to.have.been.calledWith(1);
+        expect(tester).to.have.been.calledWith(2);
+        expect(tester).to.have.been.calledWith(3);
+        expect(tester).to.have.been.calledWith(4);
+        done();
+      }
+    );
+  });
 });


### PR DESCRIPTION
It may be the case when a takeWhileInclusive needs to take a given
amount of times after the condition is met, not just one.

By default, it's still only one.